### PR TITLE
Restore dashboard.jsp

### DIFF
--- a/SalesPipelineApp/dashboard.jsp
+++ b/SalesPipelineApp/dashboard.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib uri="http://www.isomorphic.com/isomorphic/servlet/taglib" prefix="isomorphic" %>
+<%@ taglib uri="http://www.smartclient.com/taglib" prefix="isomorphic" %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -40,7 +40,22 @@
 <script>
 // -------- run once all modules + DOM are ready --------
 isc.Page.setEvent("load", function () {
-  buildUI();
+  ensureDataSources(["pipelineDS","forecastDS","employeeDS","officeDS","customerDS"], buildUI);
+
+  // ensureDataSources loads a list of DataSources before callback runs
+  function ensureDataSources(list, callback){
+    if(list.length===0){
+      if(callback) callback();
+      return;
+    }
+    var id=list.shift();
+    var ds = isc.DataSource.get(id);
+    if(ds){
+      ensureDataSources(list, callback);
+    }else{
+      isc.DataSource.load(id, function(){ ensureDataSources(list, callback); });
+    }
+  }
 
   function buildUI () {
 
@@ -143,26 +158,28 @@ isc.Page.setEvent("load", function () {
     });
 
     // ---------- compute KPI row ----------
-    isc.DataSource.get("pipelineDS").fetchData({}, function (resp) {
-      var total=0, won=0, lost=0;
-      resp.data.forEach(r=>{
-        total+=r.potentialValue;
-        if(r.status==="Won")  won += r.potentialValue;
-        if(r.status==="Lost") lost+= r.potentialValue;
+    ensureDataSources(["pipelineDS"], function(){
+      isc.DataSource.get("pipelineDS").fetchData({}, function (resp) {
+        var total=0, won=0, lost=0;
+        resp.data.forEach(r=>{
+          total+=r.potentialValue;
+          if(r.status==="Won")  won += r.potentialValue;
+          if(r.status==="Lost") lost+= r.potentialValue;
+        });
+        var fmt=v=>isc.NumberUtil.format(v,"$#,##0.00");
+        var cards=[
+          {t:"Pipeline Potential", v:fmt(total)},
+          {t:"Orders Won",        v:fmt(won),  cls:"kpi-green"},
+          {t:"Orders Lost",       v:fmt(lost), cls:"kpi-red"}
+        ].map(k=>isc.Canvas.create({
+              width:"*", styleName:"card", padding:10,
+              contents:`<div style="font-weight:600;font-size:1.1em">${k.t}</div>
+                        <div class="kpi-value ${k.cls||''}">${k.v}</div>`
+        }));
+        dashboardPane.replaceMember(0,
+          isc.HLayout.create({width:"100%", height:110, membersMargin:15, members:cards})
+        );
       });
-      var fmt=v=>isc.NumberUtil.format(v,"$#,##0.00");
-      var cards=[
-        {t:"Pipeline Potential", v:fmt(total)},
-        {t:"Orders Won",        v:fmt(won),  cls:"kpi-green"},
-        {t:"Orders Lost",       v:fmt(lost), cls:"kpi-red"}
-      ].map(k=>isc.Canvas.create({
-            width:"*", styleName:"card", padding:10,
-            contents:`<div style="font-weight:600;font-size:1.1em">${k.t}</div>
-                      <div class="kpi-value ${k.cls||''}">${k.v}</div>`
-      }));
-      dashboardPane.replaceMember(0,
-        isc.HLayout.create({width:"100%", height:110, membersMargin:15, members:cards})
-      );
     });
   }
 });

--- a/dashboard.jsp
+++ b/dashboard.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="http://www.isomorphic.com/isomorphic/servlet/taglib" prefix="isomorphic" %>
+<%@ taglib uri="http://www.smartclient.com/taglib" prefix="isomorphic" %>
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
## Summary
- restore the root dashboard.jsp so it remains in the repo
- dashboard still loads DataSources in SalesPipelineApp version
- update the root dashboard taglib to the new SmartClient URI

## Testing
- `bash test_runner.sh` *(fails: could not find a Java JDK or JRE on your system)*

------
https://chatgpt.com/codex/tasks/task_e_6859a39125048328814e8de35f2adac1